### PR TITLE
Add multi-key support and MC256 encapsulation

### DIFF
--- a/src/main/java/com/aizistral/nochatreports/core/EncryptionUtil.java
+++ b/src/main/java/com/aizistral/nochatreports/core/EncryptionUtil.java
@@ -17,7 +17,11 @@ import org.jetbrains.annotations.Nullable;
 
 public class EncryptionUtil {
 
-	public record DetailedDecryptionInfo(Component decrypted, int keyIndex, @Nullable String encapsulation) {}
+	public record DetailedDecryptionInfo(Component decrypted, int keyIndex, @Nullable String encapsulation) {
+		public String getDecryptedText() {
+			return decrypted.getString();
+		}
+	}
 
 	public static Optional<Component> tryDecrypt(Component component) {
 		// Try out all encryptors

--- a/src/main/java/com/aizistral/nochatreports/core/EncryptionUtil.java
+++ b/src/main/java/com/aizistral/nochatreports/core/EncryptionUtil.java
@@ -37,6 +37,10 @@ public class EncryptionUtil {
 		return Optional.empty();
 	}
 
+	public static Optional<DetailedDecryptionInfo> tryDecryptDetailed(String message) {
+		return tryDecryptDetailed(Component.literal(message));
+	}
+
 	public static Optional<DetailedDecryptionInfo> tryDecryptDetailed(Component component) {
 		// Try out all encryptors
 		int index = 0;

--- a/src/main/java/com/aizistral/nochatreports/core/EncryptionUtil.java
+++ b/src/main/java/com/aizistral/nochatreports/core/EncryptionUtil.java
@@ -16,15 +16,16 @@ import net.minecraft.network.chat.contents.TranslatableContents;
 public class EncryptionUtil {
 
 	public static Optional<Component> tryDecrypt(Component component) {
-		var optional = NCRConfig.getEncryption().getEncryptor();
-		if (optional.isEmpty())
-			return Optional.empty();
+		// Try out all encryptors
+		for(Encryptor<?> encryption : NCRConfig.getEncryption().getAllEncryptors()) {
+			Component copy = recreate(component);
+			ComponentContents contents = copy.getContents();
 
-		Encryptor<?> encryption = optional.get();
-		Component copy = recreate(component);
-		ComponentContents contents = copy.getContents();
-
-		return Optional.ofNullable(tryDecrypt(copy, encryption) ? copy : null);
+			if(tryDecrypt(copy, encryption)) {
+				return Optional.of(copy);
+			}
+		}
+		return Optional.empty();
 	}
 
 	public static boolean tryDecrypt(Component component, Encryptor<?> encryptor) {

--- a/src/main/java/com/aizistral/nochatreports/encryption/AESCFB8Encryption.java
+++ b/src/main/java/com/aizistral/nochatreports/encryption/AESCFB8Encryption.java
@@ -31,6 +31,8 @@ public class AESCFB8Encryption extends AESEncryption {
 			return new AESCFB8Encryptor(key, Encryption.AES_CFB8_BASE64R);
 		} else if (this.getEncapsulation().equalsIgnoreCase("Sus16")) {
 			return new AESCFB8Encryptor(key, Encryption.AES_CFB8_SUS16);
+		} else if (this.getEncapsulation().equalsIgnoreCase("MC256")) {
+			return new AESCFB8Encryptor(key, Encryption.AES_CFB8_MC256);
 		} else {
 			throw new RuntimeException("Unknown Encapsulation: " + this.getEncapsulation());
 		}

--- a/src/main/java/com/aizistral/nochatreports/encryption/AESEncryptor.java
+++ b/src/main/java/com/aizistral/nochatreports/encryption/AESEncryptor.java
@@ -88,6 +88,9 @@ public abstract class AESEncryptor<T extends AESEncryption> extends Encryptor<T>
 				} else if (this.encryption.getEncapsulation().equalsIgnoreCase("Sus16")) {
 					return encodeSus16(ByteBuffer.allocate(encrypted.length + tuple.getB().length).put(tuple.getB())
 					.put(encrypted).array());
+				} else if (this.encryption.getEncapsulation().equalsIgnoreCase("MC256")) {
+					return encodeMC256(ByteBuffer.allocate(encrypted.length + tuple.getB().length).put(tuple.getB())
+					.put(encrypted).array());
 				} else {
 					throw new RuntimeException("Unknown Encapsulation: " + this.encryption.getEncapsulation());
 				}
@@ -98,6 +101,8 @@ public abstract class AESEncryptor<T extends AESEncryption> extends Encryptor<T>
 					return encodeBase64R(this.encryptor.doFinal(toBytes(message)));
 				} else if (this.encryption.getEncapsulation().equalsIgnoreCase("Sus16")) {
 					return encodeSus16(this.encryptor.doFinal(toBytes(message)));
+				} else if (this.encryption.getEncapsulation().equalsIgnoreCase("MC256")) {
+					return encodeMC256(this.encryptor.doFinal(toBytes(message)));
 				} else {
 					throw new RuntimeException("Unknown Encapsulation: " + this.encryption.getEncapsulation());
 				}
@@ -133,6 +138,15 @@ public abstract class AESEncryptor<T extends AESEncryption> extends Encryptor<T>
 			try {
 				candidate = internalRawDecrypt(decodeSus16Bytes(message));
 				decryptLastUsedEncapsulation = "Sus16";
+			} catch (RuntimeException ex) {
+				if(firstEx == null) firstEx = ex;
+			}
+		}
+		// next MC256
+		if (candidate == null || !candidate.startsWith("#%")) {
+			try {
+				candidate = internalRawDecrypt(decodeMC256(message));
+				decryptLastUsedEncapsulation = "MC256";
 			} catch (RuntimeException ex) {
 				if(firstEx == null) firstEx = ex;
 			}

--- a/src/main/java/com/aizistral/nochatreports/encryption/Encryption.java
+++ b/src/main/java/com/aizistral/nochatreports/encryption/Encryption.java
@@ -18,6 +18,7 @@ public abstract class Encryption {
 	public static final AESCFB8Encryption AES_CFB8_BASE64 = new AESCFB8Encryption("Base64");
 	public static final AESCFB8Encryption AES_CFB8_BASE64R = new AESCFB8Encryption("Base64R");
 	public static final AESCFB8Encryption AES_CFB8_SUS16 = new AESCFB8Encryption("Sus16");
+	public static final AESCFB8Encryption AES_CFB8_MC256 = new AESCFB8Encryption("MC256");
 	public static final AESGCMEncryption AES_GCM = new AESGCMEncryption();
 	public static final AESECBEncryption AES_ECB = new AESECBEncryption();
 	public static final CaesarEncryption CAESAR = new CaesarEncryption();

--- a/src/main/java/com/aizistral/nochatreports/encryption/Encryptor.java
+++ b/src/main/java/com/aizistral/nochatreports/encryption/Encryptor.java
@@ -13,12 +13,16 @@ import it.unimi.dsi.fastutil.chars.Char2CharArrayMap;
 import it.unimi.dsi.fastutil.chars.Char2CharMap;
 import it.unimi.dsi.fastutil.chars.Char2CharMaps;
 
+import static java.util.Map.entry;
+
 public abstract class Encryptor<T extends Encryption> {
 	protected static final SecureRandom RANDOM = new SecureRandom();
 	protected static final Char2CharMap BASE64R_SHIFTS = createBase64RShifts();
 	protected static final Char2CharMap BASE64R_SHIFTS_REVERSE = createBase64RShiftsReverse();
 	protected static final Char2CharMap SUS16_SHIFTS = createSus16Shifts();
 	protected static final Char2CharMap SUS16_SHIFTS_REVERSE = createSus16ShiftsReverse();
+
+	private static String MC256_SHIFTS = "⅛⅜⅝⅞⅓⅔✉☂☔☄⛄☃⚐✎❣♤♧♡♢⛈ªº¬«»░▒▓∅∈≡±≥≤⌠⌡÷≈°∙√ⁿ²¡‰­·₴≠×ΦΨικλοπτυφЯабвгдежзиклмнопрстуфхцчшщъыьэюяєѕіј„…⁊←↑→↓⇄＋ƏəɛɪҮүӨөʻˌ;ĸ⁰¹³⁴⁵⁶⁷⁸⁹⁺⁻⁼⁽⁾ⁱ™⧈⚔☠ᴀʙᴄᴅᴇꜰɢʜᴊᴋʟᴍɴᴏᴘꞯʀꜱᴛᴜᴠᴡʏᴢ¢¤¥©®µ¶¼½¾·‐‚†‡•‱′″‴‵‶‷‹›※‼⁂⁉⁎⁑⁒⁗℗−∓∞☀☁☈Є☲☵☽♀♂⚥♠♣♥♦♩♪♫♬♭♮♯⚀⚁⚂⚃⚄⚅ʬ⚡⛏✔❄❌❤⭐△▷▽◁◆◇○◎☆★✘⸸▲▶▼◀●◦◘⚓ᛩᛪ☺☻";
 
 	protected Encryptor() {
 		// NO-OP
@@ -136,6 +140,22 @@ public abstract class Encryptor<T extends Encryption> {
 
 	protected static byte[] decodeSus16Bytes(String string) {
 		return Encryption.BASE16.decode(toBytes(unshiftSus16(string)));
+	}
+
+	protected static String encodeMC256(byte[] data) {
+		String res = new String();
+		for (int i = 0; i < data.length; ++i) {
+			res = res + MC256_SHIFTS.charAt(data[i]&0xff);
+		}
+		return res;
+	}
+
+	protected static byte[] decodeMC256(String string) {
+		byte[] bytes = new byte[string.length()];
+		for (int i = 0; i < string.length(); ++i) {
+			bytes[i] = (byte)MC256_SHIFTS.indexOf(string.charAt(i));
+		}
+		return bytes;
 	}
 
 	protected static byte[] decodeBase64NonRBytes(String string) {

--- a/src/main/java/com/aizistral/nochatreports/gui/EncryptionConfigScreen.java
+++ b/src/main/java/com/aizistral/nochatreports/gui/EncryptionConfigScreen.java
@@ -215,7 +215,6 @@ public class EncryptionConfigScreen extends Screen {
 						});
 
 		this.addRenderableWidget(this.usedEncryptionKeyIndexButton = cycle);
-		System.out.println("Updated button with " + keyCount + " keys available. Initial is " + initialValue);
 	}
 
 	@Override

--- a/src/main/java/com/aizistral/nochatreports/gui/EncryptionConfigScreen.java
+++ b/src/main/java/com/aizistral/nochatreports/gui/EncryptionConfigScreen.java
@@ -48,7 +48,6 @@ public class EncryptionConfigScreen extends Screen {
 	private static final Component DICE_TOOLTIP = Component.translatable("gui.nochatreports.encryption_config.dice_tooltip");
 	private static final Component PASS_NOT_ALLOWED = Component.translatable("gui.nochatreports.encryption_config.pass_not_allowed");
 	private static final Component ENCRYPT_PUBLIC = Component.translatable("gui.nochatreports.encryption_config.encrypt_public");
-
 	private static final int FIELDS_Y_START = 45;
 	private final Screen previous;
 	private CustomEditBox keyField, passField;
@@ -204,7 +203,7 @@ public class EncryptionConfigScreen extends Screen {
 
 		int buttonWidth = 128;
 		CycleButton<Integer> cycle = CycleButton.<Integer>builder(value -> {
-					return Component.translatable("Encrypt with: keys[%s]", value);
+					return Component.translatable("gui.nochatreports.encryption_config.encryption_key_index", value);
 				}).withValues(indicesForLength(keyCount))
 				.displayOnlyValue()
 				.withInitialValue(initialValue)

--- a/src/main/java/com/aizistral/nochatreports/gui/EncryptionConfigScreen.java
+++ b/src/main/java/com/aizistral/nochatreports/gui/EncryptionConfigScreen.java
@@ -1,7 +1,9 @@
 package com.aizistral.nochatreports.gui;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import org.checkerframework.checker.units.qual.A;
 import org.spongepowered.include.com.google.common.base.Objects;
 
 import com.aizistral.nochatreports.config.NCRConfig;
@@ -55,6 +57,7 @@ public class EncryptionConfigScreen extends Screen {
 	private MultiLineLabel keyDesc = MultiLineLabel.EMPTY, passDesc = MultiLineLabel.EMPTY;
 	protected Checkbox encryptPublicCheck;
 	private boolean settingPassKey = false;
+	private CycleButton<Integer> usedEncryptionKeyIndexButton;
 
 	public EncryptionConfigScreen(Screen previous) {
 		super(CommonComponents.EMPTY);
@@ -171,6 +174,49 @@ public class EncryptionConfigScreen extends Screen {
 				this.keyField.setValue("");
 			}
 		}
+
+		updateUsedKeyIndexButton();
+	}
+
+	private ArrayList<Integer> indicesForLength(int length) {
+		ArrayList<Integer> indices = new ArrayList<>();
+		for(int i = 0; i < length; i++) indices.add(i);
+		return indices;
+	}
+
+	public void onUpdateUsedKeyIndex(int newKeyIndex) {
+		NCRConfig.getEncryption().setUsedEncryptionKeyIndex(newKeyIndex);
+	}
+
+	public void updateUsedKeyIndexButton() {
+		if(this.usedEncryptionKeyIndexButton != null) {
+			this.removeWidget(this.usedEncryptionKeyIndexButton);
+		}
+		int initialValue = NCRConfig.getEncryption().getUsedEncryptionKeyIndex();
+		int keyCount = keyField.getValue().split(",").length;
+		if(this.usedEncryptionKeyIndexButton != null) {
+			if(this.usedEncryptionKeyIndexButton.getValue() < keyCount) {
+				initialValue = this.usedEncryptionKeyIndexButton.getValue();
+			}else {
+				initialValue = Math.max(0, keyCount - 1);
+			}
+		}
+
+		int buttonWidth = 128;
+		CycleButton<Integer> cycle = CycleButton.<Integer>builder(value -> {
+					return Component.translatable("Encrypt with: keys[%s]", value);
+				}).withValues(indicesForLength(keyCount))
+				.displayOnlyValue()
+				.withInitialValue(initialValue)
+				.withTooltip(value -> this.minecraft.font.split(
+						Component.literal("You can have multiple keys separated by commas. This index specifies, which key is use for encrypting messages."), 250))
+				.create(this.keyField.x + this.keyField.getWidth() - buttonWidth, this.keyField.y + 24, buttonWidth, 20, CommonComponents.EMPTY,
+						(cycleButton, value) -> {
+							this.unfocusFields();
+						});
+
+		this.addRenderableWidget(this.usedEncryptionKeyIndexButton = cycle);
+		System.out.println("Updated button with " + keyCount + " keys available. Initial is " + initialValue);
 	}
 
 	@Override
@@ -234,10 +280,18 @@ public class EncryptionConfigScreen extends Screen {
 		}
 
 		if (!StringUtil.isNullOrEmpty(key)) {
-			this.validationIcon.yTexStart = this.algorithmButton.getValue().validateKey(key) ? 0 : 12;
+			boolean isValid = false;
+			for(String subKey : key.split(",")) {
+				if(this.algorithmButton.getValue().validateKey(subKey)) {
+					isValid = true;
+					break;
+				}
+			}
+			this.validationIcon.yTexStart = isValid ? 0 : 12;
 		} else {
 			this.validationIcon.yTexStart = 0;
 		}
+		updateUsedKeyIndexButton();
 	}
 
 	private void onPassphraseUpdate(String pass) {
@@ -245,9 +299,15 @@ public class EncryptionConfigScreen extends Screen {
 
 		this.settingPassKey = true;
 		if (!StringUtil.isNullOrEmpty(pass)) {
-			if (encryption.supportsPassphrases()) {
-				this.keyField.setValue(encryption.getPassphraseKey(pass));
+			StringBuilder keyList = new StringBuilder();
+			for(String subPass : pass.split(",")) {
+				if (encryption.supportsPassphrases()) {
+					if(keyList.length() > 0) keyList.append(',');
+					keyList.append(encryption.getPassphraseKey(subPass));
+				}
 			}
+			if(keyList.length() > 0)
+				this.keyField.setValue(keyList.toString());
 		} else {
 			this.onKeyUpdate(this.keyField.getValue());
 		}
@@ -273,10 +333,12 @@ public class EncryptionConfigScreen extends Screen {
 	private void onDone() {
 		var config = NCRConfig.getEncryption();
 		var encryption = this.algorithmButton.getValue();
+		var usedEncryptionKeyIndex = this.usedEncryptionKeyIndexButton.getValue();
 		config.setAlgorithm(encryption);
 		config.setEncryptionKey(!StringUtil.isNullOrEmpty(this.keyField.getValue()) ? this.keyField.getValue()
 				: encryption.getDefaultKey());
 		config.setEncryptPublic(this.encryptPublicCheck.selected());
+		config.setUsedEncryptionKeyIndex(usedEncryptionKeyIndex);
 	}
 
 	private boolean hugeGUI() {

--- a/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatComponent.java
+++ b/src/main/java/com/aizistral/nochatreports/mixins/client/MixinChatComponent.java
@@ -57,9 +57,9 @@ public class MixinChatComponent {
 		Component tooltip = Component.empty().append(Component.translatable("tag.nochatreports.encrypted",
 				Component.literal(NCRConfig.getEncryption().getAlgorithm().getName()).withStyle(ChatFormatting.BOLD)))
 				.append(CommonComponents.NEW_LINE)
-				.append(Component.translatable("Decrypted using keys[%s]", this.lastMessageKeyIndex))
+				.append(Component.translatable("tag.nochatreports.encryption_tooltip_extra_key", this.lastMessageKeyIndex))
 				.append(CommonComponents.NEW_LINE)
-				.append(Component.translatable("Used Encapsulation: %s", this.lastMessageEncapsulation == null ? "Unknown" : this.lastMessageEncapsulation))
+				.append(Component.translatable("tag.nochatreports.encryption_tooltip_extra_encapsultation", this.lastMessageEncapsulation == null ? "Unknown" : this.lastMessageEncapsulation))
 				.append(CommonComponents.NEW_LINE)
 				.append(Component.translatable("tag.nochatreports.encrypted_original", this.lastMessageOriginal));
 

--- a/src/main/resources/assets/nochatreports/lang/en_us.json
+++ b/src/main/resources/assets/nochatreports/lang/en_us.json
@@ -22,6 +22,8 @@
 	"tag.nochatreports.encrypted_original": "Non-decrypted: %1$s",
 	"gui.nochatreports.encryption_tooltip": "§lEncryption:§r %1$s\nRight-click to configure.\n\nWhile encryption is enabled, you can prevent it from being applied to the message by holding §n§lCtrl§r when sending it.",
 	"gui.nochatreports.encryption_tooltip_invalid": "§lEncryption:§r %1$s\n§cInvalid configuration. Click to configure.",
+	"tag.nochatreports.encryption_tooltip_extra_key": "Decrypted using keys[%s]",
+	"tag.nochatreports.encryption_tooltip_extra_encapsultation": "Used Encapsulation: %s",
 	"gui.nochatreports.encryption_state_on": "§a§lEnabled§r",
 	"gui.nochatreports.encryption_state_off": "§c§lDisabled§r",
 	"gui.nochatreports.encryption_warning.header": "About Encryption",

--- a/src/main/resources/assets/nochatreports/lang/en_us.json
+++ b/src/main/resources/assets/nochatreports/lang/en_us.json
@@ -40,6 +40,7 @@
 	"gui.nochatreports.encryption_config.algorithm": "Algorithm: %1$s",
 	"gui.nochatreports.encryption_config.default_key": "<default: %1$s>",
 	"gui.nochatreports.encryption_config.encrypt_public": "Encrypt public messages",
+	"gui.nochatreports.encryption_config.encryption_key_index": "Encrypt with: keys[%s]",
 	"algorithm.nochatreports.aes_cfb8_base64.name": "AES/CFB8+Base64",
 	"algorithm.nochatreports.aes_cfb8_base64": "§lAES/CFB8+Base64§r\nStandard symmetric encryption algorithm. Uses 128 bit keys, output is encoded in special version of Base64 to permit transfer via Minecraft's chat. As a downside - messages will gain roughly 30% increase in length, and server might truncate them if they exceed size limit.",
 	"algorithm.nochatreports.aes_cfb8_base64r.name": "AES/CFB8+Base64R",

--- a/src/main/resources/assets/nochatreports/lang/en_us.json
+++ b/src/main/resources/assets/nochatreports/lang/en_us.json
@@ -47,6 +47,8 @@
 	"algorithm.nochatreports.aes_cfb8_base64r": "§lAES/CFB8+Base64R§r\nStandard symmetric encryption algorithm. Uses 128 bit keys, output is encoded in special version of Base64 to permit transfer via Minecraft's chat. As a downside - messages will gain roughly 30% increase in length, and server might truncate them if they exceed size limit.",
 	"algorithm.nochatreports.aes_cfb8_sus16.name": "AES/CFB8+Sus16",
 	"algorithm.nochatreports.aes_cfb8_sus16": "§lAES/CFB8+Sus16§r\nYou are a really sussy baka with this!\nBut sussy bakas cannot write much!",
+	"algorithm.nochatreports.aes_cfb8_mc256.name": "AES/CFB8+MC256",
+	"algorithm.nochatreports.aes_cfb8_mc256": "§lAES/CFB8+MC256§r\nb256 to save space\nencryption",
 	"algorithm.nochatreports.aes_gcm_base64r.name": "AES/GCM+Base64R",
 	"algorithm.nochatreports.aes_gcm_base64r": "§lAES/GCM+Base64R§r\nMore security in exchange for severe increase in message size (12 bytes for initialization vector and 12 for authentication tag, Base64 encoding on top). Choose if you value security over anything else.",
 	"algorithm.nochatreports.aes_ecb_base64r.name": "AES/ECB+Base64R",


### PR DESCRIPTION
Multiple keys are now supported. It also now shows the correct encapsulation as well as which key was used to decrypt a message.

More details and screenshots: https://github.com/EnderKill98/No-Chat-Reports/releases/tag/1.19.2-v1.13.12-1